### PR TITLE
빌드 환경 및 의존성 버전 업그레이드

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,16 +28,13 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions {
         jvmTarget = "1.8"
-    }
-    packagingOptions {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
     }
 }
 
@@ -52,4 +49,6 @@ dependencies {
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
+
+    coreLibraryDesugaring(libs.android.desugar)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,11 @@ plugins {
 
 android {
     namespace = "dev.yjyoon.kwnotice"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "dev.yjyoon.kwnotice"
         minSdk = 24
-        targetSdk = 33
         versionCode = 11
         versionName = "2.2.1"
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath(libs.android.gradle)
-        classpath(libs.kotlin.gradle)
+        classpath(libs.android.gradle.plugin)
+        classpath(libs.kotlin.gradle.plugin)
         classpath(libs.google.services)
         classpath(libs.hilt.gradle)
     }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -12,7 +12,7 @@ properties.load(project.rootProject.file("local.properties").inputStream())
 
 android {
     namespace = "dev.yjyoon.kwnotice.data"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,44 +1,44 @@
 [versions]
-kotlin = "1.7.20"
-coroutines = "1.6.4"
+kotlin = "1.9.23"
+coroutines = "1.8.0"
+android-gradle-plugin = "8.4.0"
 
-android-gradle = "8.4.0"
-androidx-core = "1.9.0"
-androidx-lifecycle = "2.5.1"
-androidx-activity = "1.6.1"
-androidx-navigation = "2.5.3"
+androidx-core = "1.13.1"
+androidx-lifecycle = "2.7.0"
+androidx-activity = "1.9.0"
+androidx-navigation = "2.7.7"
 
-compose = "1.3.3"
-compose-compiler = "1.3.2"
-material = "1.3.1"
-material3 = "1.0.1"
-dagger = "2.44"
+compose = "1.6.7"
+compose-compiler = "1.5.13"
+material = "1.6.7"
+material3 = "1.2.1"
+dagger = "2.46.1"
 
-room = "2.5.0"
-datastore = "1.0.0"
+room = "2.6.1"
+datastore = "1.1.1"
 
-gms = "4.3.15"
-firebase = "31.2.0"
+gms = "4.4.1"
+firebase = "33.0.0"
 accompanist = "0.28.0"
 
-okhttp = "4.9.3"
+okhttp = "4.11.0"
 retrofit = "2.9.0"
-gson = "2.9.0"
+gson = "2.10.1"
 
-desugar = "1.2.2"
+desugar = "2.0.4"
 junit = "4.13.2"
 
 [libraries]
 # Android
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
-
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
-android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
-
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+
+android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
 
 # Compose
 compose-ui-core = { module = "androidx.compose.ui:ui", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.7.20"
 coroutines = "1.6.4"
 
-android-gradle = "7.4.0"
+android-gradle = "8.4.0"
 androidx-core = "1.9.0"
 androidx-lifecycle = "2.5.1"
 androidx-activity = "1.6.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 01 20:05:26 KST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "dev.yjyoon.kwnotice.presentation"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24


### PR DESCRIPTION
## Issue
Close: #83 

## Description
- compileSDK 버전 `33` -> `34`
- Kotlin 버전 `1.7.20` -> `1.9.23`
- agp 버전 `7.4` -> `8.4`
- 그 외 의존성 라이브러리 버전 업그레이드